### PR TITLE
Update to go 1.18; use generics

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.16
+    - name: Set up Go 1.18
       uses: actions/setup-go@v1
       with:
-        go-version: 1.16
+        go-version: 1.18
       id: go
 
     - name: Check out code

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ all:
 
 init:
 	go install github.com/smartystreets/goconvey@v1.7.2
-	go install honnef.co/go/tools/cmd/staticcheck@2021.1.2
+	go install honnef.co/go/tools/cmd/staticcheck@2022.1.3
 	go install github.com/sergey-a-berezin/gocovcheck@v1.3.0
 	go install github.com/sergey-a-berezin/gocovcheck/jsonread@v1.3.0
 	@echo "Bootstrap done!"

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/stockparfait/parallel
 
-go 1.16
+go 1.18
 
 require github.com/smartystreets/goconvey v1.7.2
+
+require (
+	github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 // indirect
+	github.com/jtolds/gls v4.20.0+incompatible // indirect
+	github.com/smartystreets/assertions v1.2.0 // indirect
+)


### PR DESCRIPTION
Generics introduced in go 1.18 are perfect for the parallel API, hence the API change.

Part of stockparfait/stockparfait#23